### PR TITLE
feat: support relative path & support get toolchain via wget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential bc gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi libssl-dev libfl-dev
-          sudo apt-get install -y curl git ftp lftp wget libarchive-tools ccache
+          sudo apt-get install -y curl git ftp lftp wget libarchive-tools ccache python2 python2-dev
           sudo apt-get install -y zip unzip tar gzip bzip2 rar unrar
 
       - name: "🚄 Create cache key from `repos`"
@@ -72,7 +72,9 @@ jobs:
         if: ${{ env.ccache == 'true' }}
         uses: actions/cache@v3
         with:
-          path: ~/.ccache
+          path: |
+            ~/.ccache
+            ${{ env.OUT_DIR }}
           key: ccache-${{ env.KERNEL_NAME }}-${{ steps.ccache_key.outputs.CACHE_KEY }}-${{ env.builddate }}
           restore-keys: |
             ccache-${{ env.KERNEL_NAME }}-${{ steps.ccache_key.outputs.CACHE_KEY }}-${{ env.builddate }}
@@ -158,17 +160,26 @@ jobs:
             args="$args ARCH=$ARCH"
           fi
           if [ -n "$CC" ]; then
+
+            if [[ "$CC" == *"/"* ]]; then
+              CC=${{ env.WORKSPACE }}/$CC
+            fi
+
             if [ ${{ env.ccache }} = true ]; then
-              args="$args CC=\"ccache ${{ env.WORKSPACE }}/$CC\""
-              # echo "CC=ccache ${{ env.WORKSPACE }}/$CC" >> $GITHUB_ENV
+              args="$args CC=\"ccache $CC\""
             else
-              args="$args CC=${{ env.WORKSPACE }}/$CC"
+              args="$args CC=$CC"
             fi
           fi
           while read -r externalCommand; do
-            args="$args $externalCommand"
-          done < <(jq -r '.externalCommand | to_entries[] | "\(.key)=${{ env.WORKSPACE }}/\(.value)"' <<< "$params")
-
+            key=$(echo "$externalCommand" | cut -d= -f1)
+            value=$(echo "$externalCommand" | cut -d= -f2)
+            if [[ "$value" == *"/"* ]]; then
+              value="${{ env.WORKSPACE }}/$value"
+            fi
+            args="$args $key=$value"
+          done < <(jq -r '.externalCommand | to_entries[] | "\(.key)=\(.value)"' <<< "$params")
+        
           echo "🤔 $args"
           echo "ARCH=$ARCH" >> $GITHUB_OUTPUT
           echo "args=$args" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,9 @@ jobs:
       - name: "⭐ Install prerequisites"
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential bc curl git zip ftp gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi libssl-dev lftp zstd wget libfl-dev python2 python3 libarchive-tools ccache
+          sudo apt-get install -y build-essential bc gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi libssl-dev libfl-dev
+          sudo apt-get install -y curl git ftp lftp wget libarchive-tools ccache
+          sudo apt-get install -y zip unzip tar gzip bzip2 rar unrar
 
       - name: "🚄 Create cache key from `repos`"
         if: ${{ env.ccache == 'true' }}
@@ -65,7 +67,7 @@ jobs:
         run: |
           ccache -o compression=false -o cache_dir=$HOME/.ccache
           echo "CACHE_KEY=$(echo -n '${{ toJSON(matrix.repos) }}' | base64 -w 0 | cut -c -48)" >> $GITHUB_OUTPUT
-  
+
       - name: "🚅 Cache ccache files"
         if: ${{ env.ccache == 'true' }}
         uses: actions/cache@v3
@@ -99,11 +101,38 @@ jobs:
           echo "🤔 There is $toolchains_num defined toolchains."
           for ((i=0;i<toolchains_num;i++)); do
             toolchain_name=$(echo $toolchains | jq -r ".[$i].name")
+            # Github
             toolchain_repo=$(echo $toolchains | jq -r ".[$i].repo")
             toolchain_branch=$(echo $toolchains | jq -r ".[$i].branch")
-
-            git clone --recursive --depth=1 -j $(nproc) --branch $toolchain_branch $toolchain_repo $toolchain_name
-            echo "🤔 Clone $toolchain_name => ($toolchain_repo)"
+            # From archive
+            toolchain_url=$(echo $toolchains | jq -r ".[$i].url")
+            
+            echo $toolchain_url
+            if [ -z "${toolchain_url:-}" ] || [ "$toolchain_url" = "null" ];  then
+              git clone --recursive --depth=1 -j $(nproc) --branch $toolchain_branch $toolchain_repo $toolchain_name
+              echo "🤔 Clone $toolchain_name => ($toolchain_repo)"
+            else
+              wget "$toolchain_url"
+              filename="${toolchain_url##*/}"
+              mkdir -p $toolchain_name
+              case "$filename" in
+                *.zip)
+                  unzip -d $toolchain_name "$filename"
+                  ;;
+                *.tar)
+                  tar xvf "$filename" -C $toolchain_name
+                  ;;
+                *.tar.gz)
+                  tar zxvf "$filename" -C $toolchain_name
+                  ;;
+                *.rar)
+                  unrar x "$filename" $toolchain_name
+                  ;;
+                *)
+                  echo "unknown file type: $filename"
+                  ;;
+              esac
+            fi
 
             jq -r ".[$i].binPath[] | tostring" <<< "$toolchains" | while read -r bin_path; do
               echo "$WORKSPACE/$toolchain_name/$bin_path" >> $GITHUB_PATH

--- a/README.md
+++ b/README.md
@@ -270,8 +270,61 @@ This is an array that contains many repository objects of cross-compilation tool
 | ------------------- | ------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `repo`              | String | Toolchain Repository Address | The `git` repository address of the toolchain.                                                                                                                                        |
 | `branch`            | String | Toolchain Branch             | The specified branch of the repository.                                                                                                                                               |
+| `url`          | String | Toolchain Download Url   | The download url of the toolchain.                                                                                                 |
 | `name`              | String | Toolchain Name               | The name of the folder cloned locally, customized.                                                                                                                                    |
 | `binPath`           | Array  | Toolchain Binary File Path   | The path of the `bin` file used during compilation (relative to the path of the cloned folder). It will be converted to an **absolute path** during parameter setting when compiling. |
+
+Therefore, you can use the following forms to obtain the compilation toolchain:
+
+#### 1. Use `Git` to pull the toolchain
+
+```json
+"toolchains": [
+  {
+    "repo": "https://github.com/kdrag0n/proton-clang",
+    "branch": "master",
+    "name": "proton-clang",
+    "binPath": ["./bin"]
+  }
+]
+```
+
+#### 2. Use `wget` to download the toolchain
+
+In this way, you can get the compiled toolchain compressed package in `.zip` | `.tar` | `.tar.gz` | `.rar` format.
+
+```json
+"toolchains": [
+  {
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/master-kernel-build-2022/clang-r450784d.tar.gz",
+    "name": "clang",
+    "binPath": ["./bin"]
+  },
+  {
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz",
+    "name": "gcc",
+    "binPath": ["bin"]
+  }
+]
+```
+
+#### 3. Mixed mode (using `Git` and `wget` at the same time)
+
+```json
+"toolchains": [,
+  {
+    "repo": "https://gitlab.com/ThankYouMario/android_prebuilts_clang-standalone/",
+    "branch": "11",
+    "name": "clang",
+    "binPath": ["bin"]
+  },
+  {
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz",
+    "name": "gcc",
+    "binPath": ["bin"]
+  }
+]
+```
 
 ### Compilation Parameters (params)
 
@@ -366,9 +419,8 @@ This is just a suggestion, and we do not provide a specific guide.
 
 # TODO list
 
-- Add `.tar.gz` files via `wget` for third-party compilers (use `git` for toolchain now).
-- Added relative path support for third-party compilers (absolute paths are now used).
 - Use `MagiskBoot` to generate `boot.img`
+- Web page for configuring profiles
 
 # Acknowledgments
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -269,8 +269,61 @@ Set-repos 作业从配置文件中读取内核源，并将其输出到 Build-Ker
 | -------------- | ------ | -------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `repo`         | 字符串 | 工具链仓库地址       | 工具链对应的 `git` 仓库地址                                                                                          |
 | `branch`       | 字符串 | 工具链所在分支       | 对应仓库的指定分支                                                                                                   |
+| `url`          | 字符串 | 工具链所在下载地址   | 对应编译工具链的地址                                                                                                 |
 | `name`         | 字符串 | 工具链名称           | 克隆到本地的文件夹名称，自定义                                                                                       |
 | `binPath`      | 数组   | 工具链二进制文件路径 | 编译时候会用到的 `bin` 文件所在的路径(相对于克隆后所在文件夹的路径)<br/>在编译的时候会转化为**绝对路径**进行参数设置 |
+
+因此你可以使用如下几形式来获取编译工具链:
+
+#### 1. 使用 `Git` 拉取编译工具链
+
+```json
+"toolchains": [
+  {
+    "repo": "https://github.com/kdrag0n/proton-clang",
+    "branch": "master",
+    "name": "proton-clang",
+    "binPath": ["./bin"]
+  }
+]
+```
+
+#### 2. 使用 `wget` 下载编译工具链
+
+这种方式可以获取到 `.zip` | `.tar` | `.tar.gz` | `.rar` 格式的编译工具链压缩包。
+
+```json
+"toolchains": [
+  {
+    "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/master-kernel-build-2022/clang-r450784d.tar.gz",
+    "name": "clang",
+    "binPath": ["./bin"]
+  },
+  {
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz",
+    "name": "gcc",
+    "binPath": ["bin"]
+  }
+]
+```
+
+#### 3. 混合模式(同时使用 `Git` 和 `wget`)
+
+```json
+"toolchains": [,
+  {
+    "repo": "https://gitlab.com/ThankYouMario/android_prebuilts_clang-standalone/",
+    "branch": "11",
+    "name": "clang",
+    "binPath": ["bin"]
+  },
+  {
+    "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz",
+    "name": "gcc",
+    "binPath": ["bin"]
+  }
+]
+```
 
 ### 编译参数(params)
 
@@ -365,9 +418,8 @@ act --artifact-server-path /tmp/artifacts -v
 
 # TODO 列表
 
-- 为第三方编译器添加相对路径支持（现在使用绝对路径）。
-- 通过 `wget` 添加 `.tar.gz` 文件作为第三方编译器（现在使用 `git` 获取工具链）。
 - 使用 `MagiskBoot` 来生成 `boot.img`
+- 生成配置文件的网页
 
 # 致谢
 

--- a/repos.chopin.json
+++ b/repos.chopin.json
@@ -1,7 +1,7 @@
 [
   {
     "kernelSource": {
-      "name": "Redmi_Note_10_Proton",
+      "name": "Chopin_KernelSU_Proton",
       "repo": "https://github.com/AOSP-13-Mediatek/kernel_xiaomi_chopin",
       "branch": "r",
       "device": "chopin",
@@ -42,5 +42,5 @@
       "repo": "https://github.com/easterNday/AnyKernel3/",
       "branch": "thyme"
     }
-  }
+  }  
 ]

--- a/repos.chopin.json
+++ b/repos.chopin.json
@@ -16,7 +16,7 @@
         "binPath": ["./bin"]
       }
     ],
-    "ccache":true,
+    "ccache": true,
     "params": {
       "ARCH": "arm64",
       "CC": "proton-clang/bin/clang",
@@ -42,5 +42,5 @@
       "repo": "https://github.com/easterNday/AnyKernel3/",
       "branch": "thyme"
     }
-  }  
+  }
 ]

--- a/repos.thyme.json
+++ b/repos.thyme.json
@@ -16,7 +16,7 @@
         "binPath": ["bin"]
       }
     ],
-    "ccache":true,
+    "ccache": true,
     "params": {
       "ARCH": "arm64",
       "CC": "proton-clang/bin/clang",
@@ -34,6 +34,47 @@
         "LDGOLD": "proton-clang/bin/aarch64-linux-gnu-ld.gold",
         "LLVM_AR": "proton-clang/bin/llvm-ar",
         "LLVM_DIS": "proton-clang/bin/llvm-dis"
+      }
+    },
+    "AnyKernel3": {
+      "use": true,
+      "release": true,
+      "repo": "https://github.com/easterNday/AnyKernel3/",
+      "branch": "thyme"
+    }
+  },
+  {
+    "kernelSource": {
+      "name": "Thyme-Google",
+      "repo": "https://codeberg.org/DogDayAndroid/android_kernel_xiaomi_thyme",
+      "branch": "lineage-20.0",
+      "device": "thyme",
+      "defconfig": "thyme_defconfig"
+    },
+    "withKernelSU": false,
+    "toolchains": [
+      {
+        "repo": "https://android.googlesource.com/platform/prebuilts/gas/linux-x86",
+        "branch": "master",
+        "name": "gas",
+        "binPath": []
+      },
+      {
+        "repo": "https://gitlab.com/ThankYouMario/android_prebuilts_clang-standalone/",
+        "branch": "11",
+        "name": "clang",
+        "binPath": ["bin"]
+      }
+    ],
+    "ccache": true,
+    "params": {
+      "ARCH": "arm64",
+      "CC": "clang/bin/clang",
+      "externalCommand": {
+        "CROSS_COMPILE": "aarch64-linux-gnu-",
+        "CROSS_COMPILE_ARM32": "arm-linux-gnueabi-",
+        "CROSS_COMPILE_COMPAT": "arm-linux-gnueabi-",
+        "CLANG_TRIPLE": "aarch64-linux-gnu-"
       }
     },
     "AnyKernel3": {

--- a/repos.thyme.json
+++ b/repos.thyme.json
@@ -1,51 +1,7 @@
 [
   {
     "kernelSource": {
-      "name": "DogDay-KernelSU-Proton-release",
-      "repo": "https://codeberg.org/DogDayAndroid/android_kernel_xiaomi_thyme",
-      "branch": "lineage-20.0",
-      "device": "thyme",
-      "defconfig": "thyme_defconfig"
-    },
-    "withKernelSU": true,
-    "toolchains": [
-      {
-        "repo": "https://github.com/kdrag0n/proton-clang",
-        "branch": "master",
-        "name": "proton-clang",
-        "binPath": ["bin"]
-      }
-    ],
-    "ccache":false,
-    "params": {
-      "ARCH": "arm64",
-      "CC": "proton-clang/bin/clang",
-      "externalCommand": {
-        "CROSS_COMPILE": "proton-clang/bin/aarch64-linux-gnu-",
-        "CROSS_COMPILE_ARM32": "proton-clang/bin/arm-linux-gnueabi-",
-        "LD": "proton-clang/bin/ld.lld",
-        "AR": "proton-clang/bin/llvm-ar",
-        "NM": "proton-clang/bin/llvm-nm",
-        "OBJCOPY": "proton-clang/bin/llvm-objcopy",
-        "OBJDUMP": "proton-clang/bin/llvm-objdump",
-        "READELF": "proton-clang/bin/llvm-readelf",
-        "OBJSIZE": "proton-clang/bin/llvm-size",
-        "STRIP": "proton-clang/bin/llvm-strip",
-        "LDGOLD": "proton-clang/bin/aarch64-linux-gnu-ld.gold",
-        "LLVM_AR": "proton-clang/bin/llvm-ar",
-        "LLVM_DIS": "proton-clang/bin/llvm-dis"
-      }
-    },
-    "AnyKernel3": {
-      "use": true,
-      "release": true,
-      "repo": "https://github.com/easterNday/AnyKernel3/",
-      "branch": "thyme"
-    }
-  },
-  {
-    "kernelSource": {
-      "name": "DogDay-KernelSU-Proton-noanykernel-release",
+      "name": "Thyme-KernelSU-Proton",
       "repo": "https://codeberg.org/DogDayAndroid/android_kernel_xiaomi_thyme",
       "branch": "lineage-20.0",
       "device": "thyme",
@@ -81,52 +37,8 @@
       }
     },
     "AnyKernel3": {
-      "use": false,
-      "release": true,
-      "repo": "https://github.com/easterNday/AnyKernel3/",
-      "branch": "thyme"
-    }
-  },
-  {
-    "kernelSource": {
-      "name": "DogDay-KernelSU-Proton-anykernel-norelease",
-      "repo": "https://codeberg.org/DogDayAndroid/android_kernel_xiaomi_thyme",
-      "branch": "lineage-20.0",
-      "device": "thyme",
-      "defconfig": "thyme_defconfig"
-    },
-    "withKernelSU": false,
-    "toolchains": [
-      {
-        "repo": "https://github.com/kdrag0n/proton-clang",
-        "branch": "master",
-        "name": "proton-clang",
-        "binPath": ["bin"]
-      }
-    ],
-    "ccache":true,
-    "params": {
-      "ARCH": "arm64",
-      "CC": "proton-clang/bin/clang",
-      "externalCommand": {
-        "CROSS_COMPILE": "proton-clang/bin/aarch64-linux-gnu-",
-        "CROSS_COMPILE_ARM32": "proton-clang/bin/arm-linux-gnueabi-",
-        "LD": "proton-clang/bin/ld.lld",
-        "AR": "proton-clang/bin/llvm-ar",
-        "NM": "proton-clang/bin/llvm-nm",
-        "OBJCOPY": "proton-clang/bin/llvm-objcopy",
-        "OBJDUMP": "proton-clang/bin/llvm-objdump",
-        "READELF": "proton-clang/bin/llvm-readelf",
-        "OBJSIZE": "proton-clang/bin/llvm-size",
-        "STRIP": "proton-clang/bin/llvm-strip",
-        "LDGOLD": "proton-clang/bin/aarch64-linux-gnu-ld.gold",
-        "LLVM_AR": "proton-clang/bin/llvm-ar",
-        "LLVM_DIS": "proton-clang/bin/llvm-dis"
-      }
-    },
-    "AnyKernel3": {
       "use": true,
-      "release": false,
+      "release": true,
       "repo": "https://github.com/easterNday/AnyKernel3/",
       "branch": "thyme"
     }

--- a/repos.wayne.json
+++ b/repos.wayne.json
@@ -1,0 +1,51 @@
+[
+  {
+    "kernelSource": {
+      "name": "Wayne_KenrlSU_Google",
+      "repo": "https://github.com/Diva-Room/Miku_kernel_xiaomi_wayne",
+      "branch": "TDA",
+      "device": "wayne",
+      "defconfig": "vendor/wayne_defconfig"
+    },
+    "withKernelSU": false,
+    "toolchains": [
+      {
+        "url": "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/heads/master-kernel-build-2022/clang-r450784d.tar.gz",
+        "name": "clang",
+        "binPath": ["./bin"]
+      },
+      {
+        "url": "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/tags/android-12.1.0_r27.tar.gz",
+        "name": "gcc",
+        "binPath": ["bin"]
+      }
+    ],
+    "ccache": true,
+    "params": {
+      "ARCH": "arm64",
+      "CC": "clang/bin/clang",
+      "externalCommand": {
+        "CLANG_TRIPLE": "gcc/bin/aarch64-linux-android-",
+        "CROSS_COMPILE": "gcc/bin/aarch64-linux-android-",
+        "CROSS_COMPILE_ARM32": "gcc/bin/arm-linux-androideabi-",
+        "LD": "clang/bin/ld.lld",
+        "AR": "clang/bin/llvm-ar",
+        "NM": "clang/bin/llvm-nm",
+        "OBJCOPY": "clang/bin/llvm-objcopy",
+        "OBJDUMP": "clang/bin/llvm-objdump",
+        "READELF": "clang/bin/llvm-readelf",
+        "OBJSIZE": "clang/bin/llvm-size",
+        "STRIP": "clang/bin/llvm-strip",
+        "LDGOLD": "clang/bin/aarch64-linux-gnu-ld.gold",
+        "LLVM_AR": "clang/bin/llvm-ar",
+        "LLVM_DIS": "clang/bin/llvm-dis"
+      }
+    },
+    "AnyKernel3": {
+      "use": false,
+      "release": false,
+      "repo": "https://github.com/easterNday/AnyKernel3/",
+      "branch": "thyme"
+    }
+  }
+]

--- a/test.repos.json
+++ b/test.repos.json
@@ -1,136 +1,135 @@
 [
-    {
-      "kernelSource": {
-        "name": "OnePlus_KernelSU",
-        "repo": "https://github.com/tangalbert919/android_kernel_oneplus_sm8450",
-        "branch": "lineage-19.1",
-        "device": "gki",
-        "defconfig": "gki_defconfig"
-      },
-      "withKernelSU": true,
-      "toolchains": [
-        {
-          "repo": "https://github.com/CruelKernel/samsung-exynos9820-toolchain/",
-          "branch": "google",
-          "name": "google",
-          "binPath": ["./aarch64-linux-android-4.9/bin", "llvm/bin"]
-        }
-      ],
-      "params": {
-        "ARCH": "arm64",
-        "CC": "google/llvm/bin/clang",
-        "externalCommand": {
-          "CROSS_COMPILE": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-",
-          "CLANG_TRIPLE": "google/llvm/bin/aarch64-linux-android-",
-          "LD": "google/llvm/bin/ld.lld",
-          "AR": "google/llvm/bin/llvm-ar",
-          "NM": "google/llvm/bin/llvm-nm",
-          "OBJCOPY": "google/llvm/bin/llvm-objcopy",
-          "OBJDUMP": "google/llvm/bin/llvm-objdump",
-          "READELF": "google/llvm/bin/llvm-readelf",
-          "OBJSIZE": "google/llvm/bin/llvm-size",
-          "STRIP": "google/llvm/bin/llvm-strip",
-          "LDGOLD": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-ld.gold",
-          "LLVM_AR": "google/llvm/bin/llvm-ar",
-          "LLVM_DIS": "google/llvm/bin/llvm-dis"
-        }
-      },
-      "AnyKernel3": {
-        "use": false,
-        "release": true,
-        "repo": "https://github.com/easterNday/AnyKernel3/",
-        "branch": "thyme"
+  {
+    "kernelSource": {
+      "name": "OnePlus_KernelSU",
+      "repo": "https://github.com/tangalbert919/android_kernel_oneplus_sm8450",
+      "branch": "lineage-19.1",
+      "device": "gki",
+      "defconfig": "gki_defconfig"
+    },
+    "withKernelSU": true,
+    "toolchains": [
+      {
+        "repo": "https://github.com/CruelKernel/samsung-exynos9820-toolchain/",
+        "branch": "google",
+        "name": "google",
+        "binPath": ["./aarch64-linux-android-4.9/bin", "llvm/bin"]
+      }
+    ],
+    "params": {
+      "ARCH": "arm64",
+      "CC": "google/llvm/bin/clang",
+      "externalCommand": {
+        "CROSS_COMPILE": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-",
+        "CLANG_TRIPLE": "google/llvm/bin/aarch64-linux-android-",
+        "LD": "google/llvm/bin/ld.lld",
+        "AR": "google/llvm/bin/llvm-ar",
+        "NM": "google/llvm/bin/llvm-nm",
+        "OBJCOPY": "google/llvm/bin/llvm-objcopy",
+        "OBJDUMP": "google/llvm/bin/llvm-objdump",
+        "READELF": "google/llvm/bin/llvm-readelf",
+        "OBJSIZE": "google/llvm/bin/llvm-size",
+        "STRIP": "google/llvm/bin/llvm-strip",
+        "LDGOLD": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-ld.gold",
+        "LLVM_AR": "google/llvm/bin/llvm-ar",
+        "LLVM_DIS": "google/llvm/bin/llvm-dis"
       }
     },
-    {
-      "kernelSource": {
-        "name": "Panda35064-chopin",
-        "repo": "https://github.com/YuyukoAOSPMod/kernel_xiaomi_chopin",
-        "branch": "12.1",
-        "device": "chopin",
-        "defconfig": "chopin_defconfig"
-      },
-      "withKernelSU": true,
-      "toolchains": [
-        {
-          "repo": "https://github.com/CruelKernel/samsung-exynos9820-toolchain/",
-          "branch": "google",
-          "name": "google",
-          "binPath": ["./aarch64-linux-android-4.9/bin", "llvm/bin"]
-        }
-      ],
-      "params": {
-        "ARCH": "arm64",
-        "CC": "google/llvm/bin/clang",
-        "externalCommand": {
-          "CROSS_COMPILE": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-",
-          "CLANG_TRIPLE": "google/llvm/bin/aarch64-linux-android-",
-  
-          "LD": "google/llvm/bin/ld.lld",
-          "AR": "google/llvm/bin/llvm-ar",
-          "NM": "google/llvm/bin/llvm-nm",
-          "OBJCOPY": "google/llvm/bin/llvm-objcopy",
-          "OBJDUMP": "google/llvm/bin/llvm-objdump",
-          "READELF": "google/llvm/bin/llvm-readelf",
-          "OBJSIZE": "google/llvm/bin/llvm-size",
-          "STRIP": "google/llvm/bin/llvm-strip",
-          "LDGOLD": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-ld.gold",
-          "LLVM_AR": "google/llvm/bin/llvm-ar",
-          "LLVM_DIS": "google/llvm/bin/llvm-dis"
-        }
-      },
-      "AnyKernel3": {
-        "use": false,
-        "release": true,
-        "repo": "https://github.com/easterNday/AnyKernel3/",
-        "branch": "thyme"
-      }
-    },
-    {
-      "kernelSource": {
-        "name": "SM-N976N",
-        "repo": "https://github.com/easterNday/samsung-exynos9820/",
-        "branch": "devel",
-        "device": "exynos9820-d2xks",
-        "defconfig": "exynos9820-d2xks_defconfig"
-      },
-      "withKernelSU": false,
-      "toolchains": [
-        {
-          "repo": "https://github.com/CruelKernel/samsung-exynos9820-toolchain/",
-          "branch": "samsung",
-          "name": "samsung",
-          "binPath": [
-            "clang/host/linux-x86/clang-r349610-jopp/bin",
-            "gcc-cfp/gcc-cfp-jopp-only/aarch64-linux-android-4.9/bin"
-          ]
-        }
-      ],
-      "params": {
-        "ARCH": "arm64",
-        "CC": "google/llvm/bin/clang",
-        "externalCommand": {
-          "CROSS_COMPILE": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-",
-          "CLANG_TRIPLE": "google/llvm/bin/aarch64-linux-android-",
-          "LD": "google/llvm/bin/ld.lld",
-          "AR": "google/llvm/bin/llvm-ar",
-          "NM": "google/llvm/bin/llvm-nm",
-          "OBJCOPY": "google/llvm/bin/llvm-objcopy",
-          "OBJDUMP": "google/llvm/bin/llvm-objdump",
-          "READELF": "google/llvm/bin/llvm-readelf",
-          "OBJSIZE": "google/llvm/bin/llvm-size",
-          "STRIP": "google/llvm/bin/llvm-strip",
-          "LDGOLD": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-ld.gold",
-          "LLVM_AR": "google/llvm/bin/llvm-ar",
-          "LLVM_DIS": "google/llvm/bin/llvm-dis"
-        }
-      },
-      "AnyKernel3": {
-        "use": false,
-        "release": true,
-        "repo": "https://github.com/easterNday/AnyKernel3/",
-        "branch": "thyme"
-      }
+    "AnyKernel3": {
+      "use": false,
+      "release": true,
+      "repo": "https://github.com/easterNday/AnyKernel3/",
+      "branch": "thyme"
     }
-  ]
-  
+  },
+  {
+    "kernelSource": {
+      "name": "Panda35064-chopin",
+      "repo": "https://github.com/YuyukoAOSPMod/kernel_xiaomi_chopin",
+      "branch": "12.1",
+      "device": "chopin",
+      "defconfig": "chopin_defconfig"
+    },
+    "withKernelSU": true,
+    "toolchains": [
+      {
+        "repo": "https://github.com/CruelKernel/samsung-exynos9820-toolchain/",
+        "branch": "google",
+        "name": "google",
+        "binPath": ["./aarch64-linux-android-4.9/bin", "llvm/bin"]
+      }
+    ],
+    "params": {
+      "ARCH": "arm64",
+      "CC": "google/llvm/bin/clang",
+      "externalCommand": {
+        "CROSS_COMPILE": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-",
+        "CLANG_TRIPLE": "google/llvm/bin/aarch64-linux-android-",
+
+        "LD": "google/llvm/bin/ld.lld",
+        "AR": "google/llvm/bin/llvm-ar",
+        "NM": "google/llvm/bin/llvm-nm",
+        "OBJCOPY": "google/llvm/bin/llvm-objcopy",
+        "OBJDUMP": "google/llvm/bin/llvm-objdump",
+        "READELF": "google/llvm/bin/llvm-readelf",
+        "OBJSIZE": "google/llvm/bin/llvm-size",
+        "STRIP": "google/llvm/bin/llvm-strip",
+        "LDGOLD": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-ld.gold",
+        "LLVM_AR": "google/llvm/bin/llvm-ar",
+        "LLVM_DIS": "google/llvm/bin/llvm-dis"
+      }
+    },
+    "AnyKernel3": {
+      "use": false,
+      "release": true,
+      "repo": "https://github.com/easterNday/AnyKernel3/",
+      "branch": "thyme"
+    }
+  },
+  {
+    "kernelSource": {
+      "name": "SM-N976N",
+      "repo": "https://github.com/easterNday/samsung-exynos9820/",
+      "branch": "devel",
+      "device": "exynos9820-d2xks",
+      "defconfig": "exynos9820-d2xks_defconfig"
+    },
+    "withKernelSU": false,
+    "toolchains": [
+      {
+        "repo": "https://github.com/CruelKernel/samsung-exynos9820-toolchain/",
+        "branch": "samsung",
+        "name": "samsung",
+        "binPath": [
+          "clang/host/linux-x86/clang-r349610-jopp/bin",
+          "gcc-cfp/gcc-cfp-jopp-only/aarch64-linux-android-4.9/bin"
+        ]
+      }
+    ],
+    "params": {
+      "ARCH": "arm64",
+      "CC": "google/llvm/bin/clang",
+      "externalCommand": {
+        "CROSS_COMPILE": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-",
+        "CLANG_TRIPLE": "google/llvm/bin/aarch64-linux-android-",
+        "LD": "google/llvm/bin/ld.lld",
+        "AR": "google/llvm/bin/llvm-ar",
+        "NM": "google/llvm/bin/llvm-nm",
+        "OBJCOPY": "google/llvm/bin/llvm-objcopy",
+        "OBJDUMP": "google/llvm/bin/llvm-objdump",
+        "READELF": "google/llvm/bin/llvm-readelf",
+        "OBJSIZE": "google/llvm/bin/llvm-size",
+        "STRIP": "google/llvm/bin/llvm-strip",
+        "LDGOLD": "google/aarch64-linux-android-4.9/bin/aarch64-linux-android-ld.gold",
+        "LLVM_AR": "google/llvm/bin/llvm-ar",
+        "LLVM_DIS": "google/llvm/bin/llvm-dis"
+      }
+    },
+    "AnyKernel3": {
+      "use": false,
+      "release": true,
+      "repo": "https://github.com/easterNday/AnyKernel3/",
+      "branch": "thyme"
+    }
+  }
+]


### PR DESCRIPTION
What I do:

- Add relative support. Use absolute path if the compile params contains `/` or use relative path.
- Support get toolchains by `wget`.
- Update container to `ubuntu-latest` and fix missing `python2` errors.