### PR TITLE
Remove downloaded archive to avoid same filename conflict

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,7 @@ jobs:
                   echo "unknown file type: $filename"
                   ;;
               esac
+              rm $filename
             fi
 
             jq -r ".[$i].binPath[] | tostring" <<< "$toolchains" | while read -r bin_path; do


### PR DESCRIPTION
Refers to https://github.com/DogDayAndroid/Android-Kernel-Builder/issues/24